### PR TITLE
Fix FFI configuration for Homebrew on macOS

### DIFF
--- a/lib/idnx/idn2.rb
+++ b/lib/idnx/idn2.rb
@@ -5,6 +5,14 @@ module Idnx
     extend FFI::Library
 
     if FFI::Platform.mac?
+      # Essential, safe fix to unpatched ffi configuration management design error for brew in alternate locations.
+      if (prefix = ::ENV.fetch("HOMEBREW_PREFIX", nil))
+        lib = ::File.join(prefix, "lib")
+        unless (orig_value = ::FFI::DynamicLibrary::SEARCH_PATH).include?(lib)
+          ::FFI::DynamicLibrary.send(:remove_const, :SEARCH_PATH) # Necessary to avoid redefinition warning.
+          ::FFI::DynamicLibrary::SEARCH_PATH = orig_value.dup.unshift(lib).freeze
+        end
+      end
       ffi_lib ["libidn2", "libidn2.0"]
     else
       ffi_lib ["libidn2.so", "libidn2.so.0"]


### PR DESCRIPTION
While it appears to work for brew installed to platform-variable default location that requires `sudo` to taint a machine, it doesn't work with alternate locations where `HOMEBREW_PREFIX` is set. This is a show-stopping failure.